### PR TITLE
feat: expose unknown field errors through the API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ keywords = ["serde", "view", "derive"]
 readme = "README.md"
 
 [dependencies]
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_view_macros = { version = "0.1.5", path = "serde_view_macros" }
 
 [dev-dependencies]
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ fn serialize(my: &MyStruct) -> Result<serde_json::Value, serde_json::Error> {
     serde_json::to_value(my.as_view().with_fields([
        <MyStruct as View>::Fields::Id,
        <MyStruct as View>::Fields::Name,
-   ]))
+   ]).unwrap())
 }
 ```

--- a/serde_view_macros/src/lib.rs
+++ b/serde_view_macros/src/lib.rs
@@ -99,22 +99,22 @@ fn view_fields(name: &Ident, data: &DataStruct) -> TokenStream {
                 }
             }
 
-            fn from_str(name: &str) -> Option<Self> {
-                Some(match name {
+            fn from_str(name: &str) -> serde_view::Result<Self> {
+                Ok(match name {
                     #(#from_str_impl_1, )*
-                    _ => return None,
+                    s => return Err(serde_view::Error::UnknownField(s.to_string())),
                 })
             }
 
         }
 
         impl std::str::FromStr for #name {
-            type Err = ();
+            type Err = serde_view::Error;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 Ok(match s {
                     #(#from_str_impl_2, )*
-                    _ => return Err(()),
+                    s => return Err(serde_view::Error::UnknownField(s.to_string())),
                 })
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,26 +29,26 @@
 //!
 //! #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, View)]
 //! pub struct MyStruct {
-//! #    id: String,
-//! #    #[serde(default)]
-//! #    name: String,
-//! #    #[serde(default)]
-//! #    tags: Vec<String>,
+//!     id: String,
+//!     #[serde(default)]
+//!     name: String,
+//!     #[serde(default)]
+//!     tags: Vec<String>,
 //! }
 //!
 //! fn serialize(my: &MyStruct) -> Result<serde_json::Value, serde_json::Error> {
 //!     serde_json::to_value(my.as_view().with_fields([
 //!         <MyStruct as View>::Fields::Id,
 //!         <MyStruct as View>::Fields::Name,
-//!     ]))
+//!     ]).unwrap())
 //! }
 //!
 //! fn serialize_str_fields(my: &MyStruct) -> Result<serde_json::Value, serde_json::Error> {
-//!     // as fields can be converted to strings, it is also possible to something like a
+//!     // as fields can be converted to strings, it is also possible to pass something like a
 //!     // comma separated list
 //!     serde_json::to_value(my.as_view().with_fields(
-//!         <MyStruct as View>::Fields::from_str_iter("id,name".split(","))
-//!     ))
+//!         <MyStruct as View>::Fields::from_str_split("id,name").unwrap()
+//!     ).unwrap())
 //! }
 //! ```
 
@@ -57,36 +57,47 @@ mod ser;
 pub use ser::*;
 pub use serde_view_macros::View;
 
-use std::{collections::HashSet, hash::Hash};
+use std::{collections::HashSet, fmt, hash::Hash};
 
 pub trait ViewFields: Clone + Copy + Hash + PartialEq + Eq {
     fn as_str(&self) -> &'static str;
-    fn from_str(name: &str) -> Option<Self>;
+    fn from_str(name: &str) -> Result<Self>;
 
-    fn from_str_iter<'a>(names: impl IntoIterator<Item = &'a str>) -> HashSet<Self> {
-        names.into_iter().filter_map(Self::from_str).collect()
+    fn from_str_iter<'a>(names: impl IntoIterator<Item = &'a str>) -> Result<HashSet<Self>> {
+        names.into_iter().map(Self::from_str).collect()
     }
 
-    fn from_str_split(names: &str) -> HashSet<Self> {
-        Self::from_str_iter(names.split(","))
+    fn from_str_split(names: &str) -> Result<HashSet<Self>> {
+        Self::from_str_iter(names.split(','))
     }
 }
 
-/// Convert something into a field, with the option to silently fail.
+#[derive(Debug, serde::Serialize)]
+pub enum Error {
+    UnknownField(String),
+}
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for Error {}
+pub type Result<T> = std::result::Result<T, Error>;
+
 pub trait IntoField<VF: ViewFields> {
-    fn into_field(self) -> Option<VF>;
+    fn into_field(self) -> Result<VF>;
 }
 
 /// Implement for all fields.
 impl<VF: ViewFields> IntoField<VF> for VF {
-    fn into_field(self) -> Option<VF> {
-        Some(self)
+    fn into_field(self) -> Result<VF> {
+        Ok(self)
     }
 }
 
 /// Implement for `&str`, using [`ViewFields::from_str`].
 impl<VF: ViewFields> IntoField<VF> for &str {
-    fn into_field(self) -> Option<VF> {
+    fn into_field(self) -> Result<VF> {
         VF::from_str(self)
     }
 }
@@ -103,37 +114,42 @@ impl<'v, T> ViewContext<'v, T>
 where
     T: View,
 {
-    pub fn with_fields<I, IF>(mut self, fields: I) -> Self
+    pub fn with_fields<I, IF>(mut self, fields: I) -> Result<Self>
     where
         I: IntoIterator<Item = IF>,
         IF: IntoField<T::Fields>,
     {
-        self.fields = fields.into_iter().filter_map(|f| f.into_field()).collect();
-        self
+        self.fields = fields
+            .into_iter()
+            .map(|f| f.into_field())
+            .collect::<Result<_>>()?;
+        Ok(self)
     }
 
-    pub fn add_fields<I, IF>(mut self, fields: I) -> Self
+    pub fn add_fields<I, IF>(mut self, fields: I) -> Result<Self>
     where
         I: IntoIterator<Item = IF>,
         IF: IntoField<T::Fields>,
     {
-        self.fields
-            .extend(fields.into_iter().filter_map(|f| f.into_field()));
-        self
+        self.fields.extend(
+            fields
+                .into_iter()
+                .map(|f| f.into_field())
+                .collect::<Result<HashSet<T::Fields>>>()?,
+        );
+        Ok(self)
     }
 
-    pub fn add_field(mut self, field: impl IntoField<T::Fields>) -> Self {
-        if let Some(field) = field.into_field() {
-            self.fields.insert(field);
-        }
-        self
+    pub fn add_field(mut self, field: impl IntoField<T::Fields>) -> Result<Self> {
+        self.fields.insert(field.into_field()?);
+        Ok(self)
     }
 }
 
 pub trait View: Sized + serde::Serialize {
     type Fields: ViewFields;
 
-    fn as_view(self: &Self) -> ViewContext<Self> {
+    fn as_view(&self) -> ViewContext<Self> {
         ViewContext {
             inner: self,
             fields: Default::default(),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -19,7 +19,7 @@ fn is_needed<V: View>(name: &str, fields: &HashSet<V::Fields>) -> bool {
         return true;
     }
 
-    if let Some(field) = V::Fields::from_str(name) {
+    if let Ok(field) = V::Fields::from_str(name) {
         fields.contains(&field)
     } else {
         false
@@ -52,7 +52,7 @@ where
     where
         T: Serialize,
     {
-        if is_needed::<V>(key, &self.fields) {
+        if is_needed::<V>(key, self.fields) {
             self.serializer.serialize_field(key, value)
         } else {
             self.serializer.skip_field(key)
@@ -231,7 +231,7 @@ where
     ) -> Result<Self::SerializeStruct, Self::Error> {
         Ok(ViewSerializeStruct {
             serializer: self.serializer.serialize_struct(name, len)?,
-            fields: &self.fields,
+            fields: self.fields,
             _marker: Default::default(),
         })
     }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -52,12 +52,12 @@ impl ViewFields for MyRecordFields {
         }
     }
 
-    fn from_str(name: &str) -> Option<Self> {
-        Some(match name {
+    fn from_str(name: &str) -> serde_view::Result<Self> {
+        Ok(match name {
             "some_string" => Self::SomeString,
             "flag" => Self::Flag,
             "optional_flag" => Self::OptionalFlag,
-            _ => return None,
+            s => return Err(serde_view::Error::UnknownField(s.to_string())),
         })
     }
 }
@@ -79,6 +79,7 @@ fn test_manual() {
             MyRecord::default()
                 .as_view()
                 .with_fields([<MyRecord as View>::Fields::SomeString])
+                .unwrap()
         )
         .unwrap(),
         json!({
@@ -94,6 +95,7 @@ fn test_derived() {
             MyRecordDerived::default()
                 .as_view()
                 .with_fields([<MyRecordDerived as View>::Fields::SomeString])
+                .unwrap()
         )
         .unwrap(),
         json!({
@@ -106,6 +108,7 @@ fn test_derived() {
             MyRecordDerived::default()
                 .as_view()
                 .with_fields([MyRecordDerivedFields::SomeString])
+                .unwrap()
         )
         .unwrap(),
         json!({
@@ -118,6 +121,7 @@ fn test_derived() {
             MyRecordDerived::default()
                 .as_view()
                 .with_fields("some_string,flag".split(","))
+                .unwrap()
         )
         .unwrap(),
         json!({


### PR DESCRIPTION
Fixes #1

This simplifies client code that needs to handle these errors at the expense of having to unwrap results that are known to be safe.